### PR TITLE
Remove flags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@
 
 ## Articles
 
-- 🇬🇧 [Detecting the unexpected in (Web) UI](https://medium.com/criteo-labs/detecting-the-unexpected-in-web-ui-fuzzing-1f3822c8a3a5) by [dubzzz](https://github.com/dubzzz/)
-- 🇬🇧 [Find the best properties for Property Based Testing](https://medium.com/@nicolasdubien/find-the-best-properties-for-property-based-testing-ee2ed9d442e1) by [dubzzz](https://github.com/dubzzz/)
-- 🇬🇧 [Introduction to Property Based Testing](https://dev.to/gcanti/introduction-to-property-based-testing-17nk) by [gcanti](https://github.com/gcanti/)
-- 🇬🇧 [Introduction to Property Based Testing](https://medium.com/criteo-labs/introduction-to-property-based-testing-f5236229d237) by [dubzzz](https://github.com/dubzzz/)
-- 🇬🇧 [Property-based testing for JavaScript developers](https://dev.to/meeshkan/property-based-testing-for-javascript-developers-21b2) by [carolstran](https://github.com/carolstran/)
+- **[en]** [Detecting the unexpected in (Web) UI](https://medium.com/criteo-labs/detecting-the-unexpected-in-web-ui-fuzzing-1f3822c8a3a5) by [dubzzz](https://github.com/dubzzz/)
+- **[en]** [Find the best properties for Property Based Testing](https://medium.com/@nicolasdubien/find-the-best-properties-for-property-based-testing-ee2ed9d442e1) by [dubzzz](https://github.com/dubzzz/)
+- **[en]** [Introduction to Property Based Testing](https://dev.to/gcanti/introduction-to-property-based-testing-17nk) by [gcanti](https://github.com/gcanti/)
+- **[en]** [Introduction to Property Based Testing](https://medium.com/criteo-labs/introduction-to-property-based-testing-f5236229d237) by [dubzzz](https://github.com/dubzzz/)
+- **[en]** [Property-based testing for JavaScript developers](https://dev.to/meeshkan/property-based-testing-for-javascript-developers-21b2) by [carolstran](https://github.com/carolstran/)
 
 ## Videos
 
-- 🇬🇧 [Modelling Dependencies via Generative Properties - Bristol JS](https://www.youtube.com/watch?v=ShlC4Ag2URI) by [willheslam](https://github.com/willheslam)
-- 🇬🇧 [Detecting the unexpected in React applications - React Europe 2020](https://www.youtube.com/watch?list=PLCC436JpVnK0Q4WHoB85ZYBwcCyTaMgAl&v=GIPbY75-lEo&feature=emb_logo) by [dubzzz](https://github.com/dubzzz/)
-- 🇫🇷 [Property Based Testing, from theory to practice - BestOfWeb 2019](https://youtu.be/GigiViV-GFk) by [dubzzz](https://github.com/dubzzz/)
-- 🇫🇷 [Detecting the unexpected, Let's fuzz UI - Meetup React.js Paris](https://www.youtube.com/watch?v=CiD0khq8uPs) by [dubzzz](https://github.com/dubzzz/)
+- **[en]** [Modelling Dependencies via Generative Properties - Bristol JS](https://www.youtube.com/watch?v=ShlC4Ag2URI) by [willheslam](https://github.com/willheslam)
+- **[en]** [Detecting the unexpected in React applications - React Europe 2020](https://www.youtube.com/watch?list=PLCC436JpVnK0Q4WHoB85ZYBwcCyTaMgAl&v=GIPbY75-lEo&feature=emb_logo) by [dubzzz](https://github.com/dubzzz/)
+- **[fr]** [Property Based Testing, from theory to practice - BestOfWeb 2019](https://youtu.be/GigiViV-GFk) by [dubzzz](https://github.com/dubzzz/)
+- **[fr]** [Detecting the unexpected, Let's fuzz UI - Meetup React.js Paris](https://www.youtube.com/watch?v=CiD0khq8uPs) by [dubzzz](https://github.com/dubzzz/)
 
 ## Packages
 


### PR DESCRIPTION
Removing flags in favor of language codes. [Flags represent nations, not languages](http://www.flagsarenotlanguages.com/).

Some obviously controversial flags: [United Kingdom](https://en.wikipedia.org/wiki/Geographical_distribution_of_English_speakers), [Spain](https://en.wikipedia.org/wiki/Hispanophone), [France](https://en.wikipedia.org/wiki/Geographical_distribution_of_French_speakers), [Portugal](https://en.wikipedia.org/wiki/Geographical_distribution_of_Portuguese_speakers). These examples have more speakers outside the origin country than within and is a very Euro-centric, colonial viewpoint of language to use any flag whatsoever. Not to mention, many countries have more than one language which further propagates stereotypes or belittlement of minority groups inside those countries.